### PR TITLE
Fix invalid ESL flag

### DIFF
--- a/res/ESM/Quests/Adv_Collar - 000800_Adversity Framework.esm.yaml
+++ b/res/ESM/Quests/Adv_Collar - 000800_Adversity Framework.esm.yaml
@@ -5,14 +5,14 @@ VirtualMachineAdapter:
   - Name: Adv_Collar
     Properties:
     - MutagenObjectType: ScriptObjectProperty
+      Name: PlayerRef
+      Object: 000014:Skyrim.esm
+    - MutagenObjectType: ScriptObjectProperty
       Name: ViolationReason
       Object: 000D8B:Adversity Framework.esm
     - MutagenObjectType: ScriptObjectProperty
       Name: ZapSpell
       Object: 000D8F:Adversity Framework.esm
-    - MutagenObjectType: ScriptObjectProperty
-      Name: PlayerRef
-      Object: 000014:Skyrim.esm
   Versioning:
   - Break0
   ExtraBindDataVersion: 0

--- a/res/ESM/Quests/Adv_LocUtils - 00080B_Adversity Framework.esm.yaml
+++ b/res/ESM/Quests/Adv_LocUtils - 00080B_Adversity Framework.esm.yaml
@@ -5,27 +5,6 @@ VirtualMachineAdapter:
   - Name: Adv_LocUtils
     Properties:
     - MutagenObjectType: ScriptObjectListProperty
-      Name: Holds
-      Objects:
-      - Name: ''
-        Object: 01676A:Skyrim.esm
-      - Name: ''
-        Object: 01676F:Skyrim.esm
-      - Name: ''
-        Object: 016770:Skyrim.esm
-      - Name: ''
-        Object: 01676E:Skyrim.esm
-      - Name: ''
-        Object: 01676D:Skyrim.esm
-      - Name: ''
-        Object: 016769:Skyrim.esm
-      - Name: ''
-        Object: 01676C:Skyrim.esm
-      - Name: ''
-        Object: 016772:Skyrim.esm
-      - Name: ''
-        Object: 01676B:Skyrim.esm
-    - MutagenObjectType: ScriptObjectListProperty
       Name: CrimeFactions
       Objects:
       - Name: ''
@@ -46,6 +25,27 @@ VirtualMachineAdapter:
         Object: 0267EA:Skyrim.esm
       - Name: ''
         Object: 02816F:Skyrim.esm
+    - MutagenObjectType: ScriptObjectListProperty
+      Name: Holds
+      Objects:
+      - Name: ''
+        Object: 01676A:Skyrim.esm
+      - Name: ''
+        Object: 01676F:Skyrim.esm
+      - Name: ''
+        Object: 016770:Skyrim.esm
+      - Name: ''
+        Object: 01676E:Skyrim.esm
+      - Name: ''
+        Object: 01676D:Skyrim.esm
+      - Name: ''
+        Object: 016769:Skyrim.esm
+      - Name: ''
+        Object: 01676C:Skyrim.esm
+      - Name: ''
+        Object: 016772:Skyrim.esm
+      - Name: ''
+        Object: 01676B:Skyrim.esm
     - MutagenObjectType: ScriptObjectProperty
       Name: PlayerRef
       Object: 000014:Skyrim.esm

--- a/res/ESM/Quests/Adv_Main - 002318_Adversity Framework.esm.yaml
+++ b/res/ESM/Quests/Adv_Main - 002318_Adversity Framework.esm.yaml
@@ -5,14 +5,14 @@ VirtualMachineAdapter:
   - Name: Adv_Main
     Properties:
     - MutagenObjectType: ScriptObjectProperty
+      Name: LicenseUtil
+      Object: 000802:Adversity Framework.esm
+    - MutagenObjectType: ScriptObjectProperty
       Name: SleepUtil
       Object: 000D7E:Adversity Framework.esm
     - MutagenObjectType: ScriptObjectProperty
       Name: Sync
       Object: 001DB5:Adversity Framework.esm
-    - MutagenObjectType: ScriptObjectProperty
-      Name: LicenseUtil
-      Object: 000802:Adversity Framework.esm
   FileName: ''
   Aliases:
   - Property:

--- a/res/ESM/Quests/Adv_SleepUtils - 000D7E_Adversity Framework.esm.yaml
+++ b/res/ESM/Quests/Adv_SleepUtils - 000D7E_Adversity Framework.esm.yaml
@@ -5,20 +5,20 @@ VirtualMachineAdapter:
   - Name: Adv_SleepUtils
     Properties:
     - MutagenObjectType: ScriptObjectProperty
-      Name: WoozyGetUp
-      Object: 0CF2C6:Skyrim.esm
+      Name: GameHour
+      Object: 000038:Skyrim.esm
     - MutagenObjectType: ScriptObjectProperty
       Name: Marker
       Object: 00080A:Adversity Framework.esm
     - MutagenObjectType: ScriptObjectProperty
-      Name: GameHour
-      Object: 000038:Skyrim.esm
+      Name: PlayerRef
+      Object: 000014:Skyrim.esm
     - MutagenObjectType: ScriptObjectProperty
       Name: SleepyTimeFadeIn
       Object: 0F342B:Skyrim.esm
     - MutagenObjectType: ScriptObjectProperty
-      Name: PlayerRef
-      Object: 000014:Skyrim.esm
+      Name: WoozyGetUp
+      Object: 0CF2C6:Skyrim.esm
   Versioning:
   - Break0
   ExtraBindDataVersion: 0

--- a/res/ESM/RecordData.yaml
+++ b/res/ESM/RecordData.yaml
@@ -6,7 +6,6 @@ GameRelease: SkyrimSE
 ModHeader:
   Flags:
   - Master
-  - Small
   Author: DEFAULT
   MasterReferences:
   - Master: Skyrim.esm


### PR DESCRIPTION
Adversity has an ESL flag despite having records out of range. I removed that flag, checked xEdit for errors and then re-serialized it. Spriggit has an odd bug where it shuffles some data around, hence the diffs.